### PR TITLE
[Infra] Update revision of tools-shared

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -310,7 +310,7 @@ deps = {
     "./tools_shared": {
         "type": "solution",
         "url": "https://github.com/lynx-family/tools-shared.git",
-        "commit": "36ad60d713b56a6907cf7c5a18028a69c6853d00",
+        "commit": "0ad5be5770bb7d00bcd958236823343941564a71",
         'deps_file': 'dependencies/DEPS',
         "ignore_in_git": True,
     },


### PR DESCRIPTION

## Summary
This pull request updates the dependency configuration in the `DEPS` file. The most notable change is the update to the commit hash for the `tools-shared` repository.

Dependency updates:

* [`DEPS`](diffhunk://#diff-4cc955bcf0b472353786cc8d8b7d346fb432c091bed099de884885e938392814L313-R313): Updated the `tools-shared` dependency to point to a new commit (`0ad5be5770bb7d00bcd958236823343941564a71`) instead of the previous one (`36ad60d713b56a6907cf7c5a18028a69c6853d00`).

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
